### PR TITLE
Fix: Update OpenWeatherMap API URL to use HTTPS

### DIFF
--- a/src/redux/Pollution/pollution.js
+++ b/src/redux/Pollution/pollution.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 const FETCH_AIR_POLLUTION_DATA = 'airPollution/fetch';
 
 // API URL and key for fetching air pollution data
-const API_URL = 'http://api.openweathermap.org/data/2.5/air_pollution?';
+const API_URL = 'https://api.openweathermap.org/data/2.5/air_pollution?';
 const API_KEY = '9e828e2624199c7cbb9d9cde2d3b483c';
 
 // Define the initial state for the slice


### PR DESCRIPTION
## 🐛Fix: API URL to use HTTPS

This PR updates the URL for the OpenWeatherMap API to use HTTPS instead of HTTP to resolve a "Mixed Content" error that was occurring. The change ensures that all content on the page is served securely over HTTPS, which is a best practice for web security.

**Changes made:** 🔄

- Updated OpenWeatherMap API URL to use HTTPS instead of HTTP.
- Ensured that all content on the page is served securely over HTTPS.